### PR TITLE
Integrate simple SGF parser

### DIFF
--- a/input/sgf_parser.py
+++ b/input/sgf_parser.py
@@ -1,0 +1,60 @@
+"""Simple SGF parser used for extracting basic game information and board matrix."""
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Tuple
+
+Board = List[List[int]]
+
+
+def parse_sgf(sgf_file_path: str) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    """Parse an SGF file and return game info and list of moves."""
+    with open(sgf_file_path, "r", encoding="utf-8") as f:
+        sgf_content = f.read().strip()
+
+    game_info: Dict[str, Any] = {}
+
+    size_match = re.search(r"SZ\[(\d+)\]", sgf_content)
+    game_info["board_size"] = int(size_match.group(1)) if size_match else 19
+
+    pb_match = re.search(r"PB\[([^\]]+)\]", sgf_content)
+    game_info["black_player"] = pb_match.group(1) if pb_match else "Unknown"
+
+    pw_match = re.search(r"PW\[([^\]]+)\]", sgf_content)
+    game_info["white_player"] = pw_match.group(1) if pw_match else "Unknown"
+
+    re_match = re.search(r"RE\[([^\]]+)\]", sgf_content)
+    game_info["result"] = re_match.group(1) if re_match else "Unknown"
+
+    moves: List[Dict[str, Any]] = []
+    move_pattern = r"([BW])\[([a-z]{2})\]"
+    for color, pos in re.findall(move_pattern, sgf_content):
+        if pos:
+            x = ord(pos[0]) - ord("a")
+            y = ord(pos[1]) - ord("a")
+            moves.append({"color": color, "x": x, "y": y, "sgf_pos": pos})
+
+    return game_info, moves
+
+
+def sgf_to_input_matrix(sgf_file_path: str) -> Tuple[Board, Dict[str, Any], List[Dict[str, Any]]]:
+    """Convert SGF file to a board matrix format."""
+    game_info, moves = parse_sgf(sgf_file_path)
+    size = game_info["board_size"]
+    board: Board = [[0 for _ in range(size)] for _ in range(size)]
+
+    for move in moves:
+        x, y = move["x"], move["y"]
+        board[y][x] = 1 if move["color"] == "B" else -1
+
+    return board, game_info, moves
+
+
+def print_board(board: Board) -> None:
+    """Print a board using unicode symbols."""
+    symbols = {0: "\u00b7", 1: "\u25CF", -1: "\u25CB"}
+    for row in board:
+        print(" ".join(symbols[cell] for cell in row))
+
+
+__all__ = ["parse_sgf", "sgf_to_input_matrix", "print_board"]

--- a/tests/unit_tests/test_sgf_parser.py
+++ b/tests/unit_tests/test_sgf_parser.py
@@ -1,0 +1,35 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from input import sgf_parser
+
+
+def test_parser_moves(tmp_path: pathlib.Path):
+    sgf_content = "(;FF[4]SZ[5]PB[Black]PW[White];B[aa];W[bb];B[cc])"
+    sgf_file = tmp_path / "game.sgf"
+    sgf_file.write_text(sgf_content)
+
+    game_info, moves = sgf_parser.parse_sgf(str(sgf_file))
+
+    assert game_info["board_size"] == 5
+    assert game_info["black_player"] == "Black"
+    assert game_info["white_player"] == "White"
+    assert len(moves) == 3
+    assert moves[0]["color"] == "B"
+    assert moves[0]["x"] == 0 and moves[0]["y"] == 0
+
+
+def test_sgf_to_input_matrix(tmp_path: pathlib.Path):
+    sgf_content = "(;FF[4]SZ[5];B[aa];W[bb])"
+    sgf_file = tmp_path / "g2.sgf"
+    sgf_file.write_text(sgf_content)
+
+    board, game_info, moves = sgf_parser.sgf_to_input_matrix(str(sgf_file))
+
+    assert len(board) == 5
+    assert board[0][0] == 1
+    assert board[1][1] == -1
+    assert len(moves) == 2
+    assert game_info["board_size"] == 5


### PR DESCRIPTION
## Summary
- add new `sgf_parser` module for reading SGF info and board matrix
- include tests for parsing and converting SGF to matrix

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ee73e04083268cc71eaff6742cda