### PR TITLE
Add liberty counting utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ python main.py --mode train --data data/training/ --output data/models/strategie
 - liberty 每個棋子位置(x座標, y座標, 氣)的無序集合，黑棋正數、白棋負數 → 簡單的3維向量
 - forbidden 禁著點位置
 - 隨機洗牌：消除順序偏見
+- 使用 `core.liberty.count_liberties()` 可以在取得棋盤後重新計算各棋子的氣數
 
 ```
 liberty = [

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,5 @@
+"""Core package for light-go."""
+
+from . import liberty
+
+__all__ = ["liberty"]

--- a/core/liberty.py
+++ b/core/liberty.py
@@ -1,0 +1,58 @@
+"""Utilities for counting liberties on a Go board."""
+from __future__ import annotations
+
+from typing import List, Set, Tuple
+
+Board = List[List[int]]
+
+
+def neighbors(x: int, y: int, size: int):
+    """Yield the coordinates adjacent to ``(x, y)`` on a ``size`` x ``size`` board."""
+    if x > 0:
+        yield x - 1, y
+    if x < size - 1:
+        yield x + 1, y
+    if y > 0:
+        yield x, y - 1
+    if y < size - 1:
+        yield x, y + 1
+
+
+def group_and_liberties(board: Board, x: int, y: int) -> Tuple[Set[Tuple[int, int]], Set[Tuple[int, int]]]:
+    """Return the connected group at ``(x, y)`` and its liberties."""
+    color = board[y][x]
+    size = len(board)
+    group = {(x, y)}
+    liberties: Set[Tuple[int, int]] = set()
+    stack = [(x, y)]
+    while stack:
+        cx, cy = stack.pop()
+        for nx, ny in neighbors(cx, cy, size):
+            val = board[ny][nx]
+            if val == 0:
+                liberties.add((nx, ny))
+            elif val == color and (nx, ny) not in group:
+                group.add((nx, ny))
+                stack.append((nx, ny))
+    return group, liberties
+
+
+def count_liberties(board: Board) -> List[Tuple[int, int, int]]:
+    """Return a list of ``(x, y, liberties)`` for all stones on the board."""
+    size = len(board)
+    visited: Set[Tuple[int, int]] = set()
+    result: List[Tuple[int, int, int]] = []
+    for y in range(size):
+        for x in range(size):
+            color = board[y][x]
+            if color == 0 or (x, y) in visited:
+                continue
+            group, libs = group_and_liberties(board, x, y)
+            for gx, gy in group:
+                visited.add((gx, gy))
+                val = len(libs) if color == 1 else -len(libs)
+                result.append((gx + 1, gy + 1, val))
+    return result
+
+
+__all__ = ["count_liberties", "group_and_liberties", "neighbors", "Board"]

--- a/input/sgf_to_input.py
+++ b/input/sgf_to_input.py
@@ -5,6 +5,7 @@ import re
 from typing import Dict, List, Tuple
 
 from core.show_board import render_board
+from core.liberty import count_liberties
 
 Board = List[List[int]]
 
@@ -112,21 +113,7 @@ def parse_sgf(path: str) -> Tuple[Board, Dict]:
 def convert(path: str) -> Dict:
     board, metadata = parse_sgf(path)
     render_board(board)
-    size = len(board)
-    liberty: List[Tuple[int, int, int]] = []
-    visited: set[Tuple[int, int]] = set()
-    for y in range(size):
-        for x in range(size):
-            color = board[y][x]
-            if color == 0:
-                continue
-            if (x, y) in visited:
-                continue
-            group, libs = _group_and_liberties(board, x, y)
-            for gx, gy in group:
-                visited.add((gx, gy))
-                val = len(libs) if color == 1 else -len(libs)
-                liberty.append((gx + 1, gy + 1, val))
+    liberty: List[Tuple[int, int, int]] = count_liberties(board)
     return {"liberty": liberty, "forbidden": [], "metadata": metadata}
 
 

--- a/tests/unit_tests/test_liberty_counter.py
+++ b/tests/unit_tests/test_liberty_counter.py
@@ -1,0 +1,19 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from input import sgf_to_input
+from core import liberty
+
+
+def test_count_liberties(tmp_path: pathlib.Path):
+    sgf_content = "(;FF[4]SZ[5];B[aa];W[bb];B[cc];W[dd])"
+    sgf_file = tmp_path / "game.sgf"
+    sgf_file.write_text(sgf_content)
+
+    board, _ = sgf_to_input.parse_sgf(str(sgf_file))
+    result = liberty.count_liberties(board)
+
+    assert (1, 1, 2) in result
+    assert len(result) == 4


### PR DESCRIPTION
## Summary
- implement `core.liberty` module for general liberty counting
- refactor `sgf_to_input.convert` to use the new utility
- expose the module through `core.__init__`
- add unit tests for `count_liberties`
- document how to recompute liberties in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842eee7d3b08326acd19178f521938b