### PR TITLE
Implement training pipeline skeleton

### DIFF
--- a/core/auto_learner.py
+++ b/core/auto_learner.py
@@ -1,0 +1,60 @@
+"""Simplified automatic learning utilities."""
+from __future__ import annotations
+
+import os
+from typing import Dict
+
+from input.sgf_to_input import parse_sgf
+from core.liberty import count_liberties
+from .strategy_manager import StrategyManager
+
+
+class AutoLearner:
+    """A very small learner that derives statistics from SGF files."""
+
+    def __init__(self, manager: StrategyManager) -> None:
+        self.manager = manager
+
+    @staticmethod
+    def _game_stats(board):
+        libs = count_liberties(board)
+        black_libs = [abs(l) for _, _, l in libs if l > 0]
+        white_libs = [abs(l) for _, _, l in libs if l < 0]
+        return {
+            "black_stones": len(black_libs),
+            "white_stones": len(white_libs),
+            "avg_liberties_black": sum(black_libs) / len(black_libs) if black_libs else 0.0,
+            "avg_liberties_white": sum(white_libs) / len(white_libs) if white_libs else 0.0,
+        }
+
+    def train(self, data_path: str) -> Dict:
+        """Compute simple aggregated statistics from all SGF files."""
+        stats = {
+            "games": 0,
+            "total_black_stones": 0,
+            "total_white_stones": 0,
+            "avg_liberties_black": 0.0,
+            "avg_liberties_white": 0.0,
+        }
+        for fname in os.listdir(data_path):
+            if not fname.endswith(".sgf"):
+                continue
+            board, _ = parse_sgf(os.path.join(data_path, fname))
+            gs = self._game_stats(board)
+            stats["games"] += 1
+            stats["total_black_stones"] += gs["black_stones"]
+            stats["total_white_stones"] += gs["white_stones"]
+            stats["avg_liberties_black"] += gs["avg_liberties_black"]
+            stats["avg_liberties_white"] += gs["avg_liberties_white"]
+        if stats["games"]:
+            stats["avg_liberties_black"] /= stats["games"]
+            stats["avg_liberties_white"] /= stats["games"]
+        return stats
+
+    def train_and_save(self, data_path: str) -> str:
+        """Train from ``data_path`` and store a new strategy."""
+        model_data = self.train(data_path)
+        existing = self.manager.list_strategies()
+        next_name = chr(ord("a") + len(existing))
+        self.manager.save_strategy(next_name, model_data)
+        return next_name

--- a/core/engine.py
+++ b/core/engine.py
@@ -1,0 +1,17 @@
+"""Main engine tying together strategy management and learning."""
+from __future__ import annotations
+
+from .strategy_manager import StrategyManager
+from .auto_learner import AutoLearner
+
+
+class Engine:
+    """Facade for high level operations."""
+
+    def __init__(self, model_dir: str) -> None:
+        self.strategy_manager = StrategyManager(model_dir)
+        self.auto_learner = AutoLearner(self.strategy_manager)
+
+    def train(self, data_dir: str) -> str:
+        """Train a new strategy from SGF files in ``data_dir``."""
+        return self.auto_learner.train_and_save(data_dir)

--- a/core/strategy_manager.py
+++ b/core/strategy_manager.py
@@ -1,0 +1,37 @@
+"""Manage loading and saving of strategy models."""
+from __future__ import annotations
+
+import os
+import pickle
+from typing import Dict, List
+
+
+class StrategyManager:
+    """Simple manager for strategy files stored as pickles."""
+
+    def __init__(self, strategies_path: str) -> None:
+        self.strategies_path = strategies_path
+        os.makedirs(self.strategies_path, exist_ok=True)
+
+    def list_strategies(self) -> List[str]:
+        """Return a sorted list of available strategy names."""
+        names = []
+        for fname in os.listdir(self.strategies_path):
+            if fname.endswith(".pkl"):
+                names.append(os.path.splitext(fname)[0])
+        return sorted(set(names))
+
+    def load_strategy(self, name: str) -> Dict:
+        """Load a strategy by name."""
+        path = os.path.join(self.strategies_path, f"{name}.pkl")
+        with open(path, "rb") as f:
+            return pickle.load(f)
+
+    def save_strategy(self, name: str, data: Dict) -> None:
+        """Save strategy data to both .pkl and .pt files."""
+        pkl_path = os.path.join(self.strategies_path, f"{name}.pkl")
+        pt_path = os.path.join(self.strategies_path, f"{name}.pt")
+        with open(pkl_path, "wb") as f:
+            pickle.dump(data, f)
+        with open(pt_path, "wb") as f:
+            pickle.dump(data, f)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,27 @@
+"""Entry point for Light-Go command line interface."""
+from __future__ import annotations
+
+import argparse
+
+from core.engine import Engine
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Light-Go")
+    parser.add_argument("--mode", choices=["train", "api", "gtp", "single"], default="train")
+    parser.add_argument("--data", help="Input data directory")
+    parser.add_argument("--output", help="Output model directory")
+    args = parser.parse_args()
+
+    if args.mode == "train":
+        if not args.data or not args.output:
+            parser.error("--data and --output are required for train mode")
+        engine = Engine(args.output)
+        name = engine.train(args.data)
+        print(f"Saved strategy {name} to {args.output}")
+    else:
+        print(f"Mode '{args.mode}' is not implemented in this simplified version")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add simple StrategyManager, AutoLearner and Engine modules
- create CLI `main.py` for training mode
- keep core package unchanged to avoid import cycles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ef848850832686c5b5a8767db810