### PR TITLE
Add GitHub workflow for sgf_to_input tests

### DIFF
--- a/.github/workflows/sgf_to_input.yml
+++ b/.github/workflows/sgf_to_input.yml
@@ -1,0 +1,25 @@
+name: SGF to Input Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - uses: py-actions/py-dependency-install@v4
+        with:
+          path: requirements.txt
+      - name: Install pip and pytest
+        run: |
+          python -m pip install --upgrade pip pytest
+      - name: Run tests
+        uses: pytest-dev/pytest-action@v2
+        with:
+          args: tests/unit_tests/test_sgf_to_input.py
+


### PR DESCRIPTION
## Summary
- add workflow sgf_to_input.yml to run unit tests on PRs using pytest-action
- fix test file path

## Testing
- `pytest tests/unit_tests/test_sgf_to_input.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685d12526eb88326be09744bc1e8d939