### PR TITLE
Add readme for unit tests

### DIFF
--- a/tests/unit_tests/readme
+++ b/tests/unit_tests/readme
@@ -1,10 +1,18 @@
 # 測試說明
 
-此資料夾存放 pytest 單元測試，其中 `sgf_to_input.py` 提供了三個測試函式：
+此資料夾存放 pytest 單元測試，其中 `sgf_to_input.py` 定義三個主要測試函式：
 
-- `test_liberty`：檢查 `sgf_to_input.convert` 依序載入 SGF 檔案時，回傳的每一步 `liberty` 是否符合預期。
-- `test_forbidden`：確認同樣的 SGF 檔案在各步驟下沒有產生禁著點。
-- `test_metadata`：逐步比對回傳的 `metadata`，例如下一手顏色、規則與時間資訊。
+1. **`test_liberty`**
+   - 透過 `_create_sgf()` 建立 5×5 的示例棋局。
+   - 逐步呼叫 `sgf_to_input.convert()`，比對每一步回傳的 `liberty` 集合。
 
-測試會產生 `.github/test_report.md`，紀錄失敗案例與時間戳記。
+2. **`test_forbidden`**
+   - 使用相同的 SGF 檔案，檢查四個步驟皆沒有產生 `forbidden` 位置。
+
+3. **`test_metadata`**
+   - 驗證 `metadata` 內容，包括規則設定、下一手顏色、步驟列表及時間資訊。
+
+若斷言失敗，輔助函式 `_append_report()` 會將差異寫入 `.github/test_report.md`，並附上時間戳記。
+
+執行 `pytest` 即可運行這些測試。
 


### PR DESCRIPTION
## Summary
- document sgf_to_input tests in `tests/unit_tests/readme`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d42bbf0588326b707af1baf05ab4b