### PR TITLE
Add FastAPI WebSocket service with tests

### DIFF
--- a/.github/workflows/websocket_api.yml
+++ b/.github/workflows/websocket_api.yml
@@ -1,0 +1,28 @@
+name: WebSocket API Tests
+
+on:
+  pull_request:
+    paths:
+      - 'api/websocket_api.py'
+      - 'tests/unit_tests/websocket_api.py'
+  push:
+    branches: [main]
+    paths:
+      - 'api/websocket_api.py'
+      - 'tests/unit_tests/websocket_api.py'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install pip and pytest
+        run: |
+          python -m pip install --upgrade pip pytest
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run WebSocket API unit tests
+        run: pytest tests/unit_tests/websocket_api.py

--- a/api/websocket_api.py
+++ b/api/websocket_api.py
@@ -1,0 +1,99 @@
+"""WebSocket inference service using FastAPI.
+
+This module exposes a ``FastAPI`` application that serves real-time predictions
+via the ``/ws/predict`` endpoint.  Multiple clients can connect concurrently and
+send JSON messages of the form ``{"input": {...}}``.  Each message is forwarded
+to :func:`core.engine.predict` and the returned value is sent back as a JSON
+object ``{"output": ...}``.
+
+Messages with the literal text ``"ping"`` will receive ``"pong"`` in response.
+Invalid JSON or missing ``input`` keys are reported back with an ``error``
+message.  Any internal exception is logged and returned to the client in a safe
+format.
+
+Running the module directly will start the service using ``uvicorn``.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, Set
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+
+from core import engine
+
+
+logger = logging.getLogger(__name__)
+app = FastAPI(title="Light-Go WebSocket API")
+
+
+class ConnectionManager:
+    """Manage active WebSocket connections."""
+
+    def __init__(self) -> None:
+        self.active_connections: Set[WebSocket] = set()
+
+    async def connect(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        self.active_connections.add(websocket)
+        logger.info("Client connected. Active: %d", len(self.active_connections))
+
+    def disconnect(self, websocket: WebSocket) -> None:
+        self.active_connections.discard(websocket)
+        logger.info(
+            "Client disconnected. Active: %d", len(self.active_connections)
+        )
+
+
+manager = ConnectionManager()
+
+
+@app.websocket("/ws/predict")
+async def ws_predict(websocket: WebSocket) -> None:
+    """Handle WebSocket prediction requests."""
+
+    await manager.connect(websocket)
+    try:
+        while True:
+            try:
+                text = await websocket.receive_text()
+            except WebSocketDisconnect:
+                raise
+
+            if text == "ping":
+                await websocket.send_text("pong")
+                continue
+
+            try:
+                payload = json.loads(text)
+            except json.JSONDecodeError:
+                await websocket.send_json({"error": "invalid_json"})
+                continue
+
+            if not isinstance(payload, dict) or "input" not in payload:
+                await websocket.send_json({"error": "missing_input"})
+                continue
+
+            input_data = payload["input"]
+            try:
+                result = engine.predict(input_data)  # type: ignore[attr-defined]
+            except Exception as exc:  # pragma: no cover - log unexpected errors
+                logger.exception("Prediction failed: %s", exc)
+                await websocket.send_json({"error": str(exc)})
+                continue
+
+            await websocket.send_json({"output": result})
+    except WebSocketDisconnect:
+        logger.info("Client disconnected from /ws/predict")
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.exception("Unexpected error: %s", exc)
+    finally:
+        manager.disconnect(websocket)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual start
+    logging.basicConfig(level=logging.INFO)
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/tests/unit_tests/websocket_api.py
+++ b/tests/unit_tests/websocket_api.py
@@ -1,0 +1,98 @@
+import json
+import pathlib
+import sys
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+from websockets.sync.client import connect
+import uvicorn
+
+# Add project root to path
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from api.websocket_api import app
+
+
+PORT = 8765
+
+
+def start_server():
+    config = uvicorn.Config(app, host="127.0.0.1", port=PORT, log_level="info")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    while not server.started:
+        time.sleep(0.1)
+    return server, thread
+
+
+def stop_server(server, thread):
+    server.should_exit = True
+    thread.join()
+
+
+def test_predict_success():
+    with patch("core.engine.predict", return_value={"move": "D4"}, create=True):
+        server, thread = start_server()
+        try:
+            ws = connect(f"ws://127.0.0.1:{PORT}/ws/predict")
+            ws.send(json.dumps({"input": {"board": []}}))
+            data = json.loads(ws.recv())
+            assert data == {"output": {"move": "D4"}}
+            ws.close()
+        finally:
+            stop_server(server, thread)
+
+
+def test_invalid_json():
+    server, thread = start_server()
+    try:
+        ws = connect(f"ws://127.0.0.1:{PORT}/ws/predict")
+        ws.send("not json")
+        data = json.loads(ws.recv())
+        assert data["error"] == "invalid_json"
+        ws.close()
+    finally:
+        stop_server(server, thread)
+
+
+def test_missing_input_key():
+    server, thread = start_server()
+    try:
+        ws = connect(f"ws://127.0.0.1:{PORT}/ws/predict")
+        ws.send(json.dumps({"foo": 1}))
+        data = json.loads(ws.recv())
+        assert data["error"] == "missing_input"
+        ws.close()
+    finally:
+        stop_server(server, thread)
+
+
+def test_ping_pong():
+    server, thread = start_server()
+    try:
+        ws = connect(f"ws://127.0.0.1:{PORT}/ws/predict")
+        ws.send("ping")
+        assert ws.recv() == "pong"
+        ws.close()
+    finally:
+        stop_server(server, thread)
+
+
+def test_disconnect_and_reconnect():
+    server, thread = start_server()
+    try:
+        ws = connect(f"ws://127.0.0.1:{PORT}/ws/predict")
+        ws.send("ping")
+        ws.recv()
+        ws.close()
+        with patch("core.engine.predict", return_value=42, create=True):
+            ws2 = connect(f"ws://127.0.0.1:{PORT}/ws/predict")
+            ws2.send(json.dumps({"input": {"x": 1}}))
+            data = json.loads(ws2.recv())
+            assert data == {"output": 42}
+            ws2.close()
+    finally:
+        stop_server(server, thread)


### PR DESCRIPTION
## Summary
- implement FastAPI websocket server at `/ws/predict`
- add unit tests for websocket API behaviour
- run websocket tests in new GitHub workflow

## Testing
- `pytest tests/unit_tests/websocket_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685e99efc884832682afc833f6dbea2e