### PR TITLE
Add FastAPI REST API with tests and CI

### DIFF
--- a/.github/workflows/rest_api.yml
+++ b/.github/workflows/rest_api.yml
@@ -1,0 +1,31 @@
+name: REST API Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - 'api/rest_api.py'
+      - 'tests/unit_tests/rest_api.py'
+      - '.github/workflows/rest_api.yml'
+  push:
+    paths:
+      - 'api/rest_api.py'
+      - 'tests/unit_tests/rest_api.py'
+      - '.github/workflows/rest_api.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - uses: py-actions/py-dependency-install@v4
+        with:
+          path: requirements.txt
+      - name: Install pip and pytest
+        run: |
+          python -m pip install --upgrade pip pytest
+      - name: Run REST API unit tests
+        run: pytest tests/unit_tests/rest_api.py

--- a/api/rest_api.py
+++ b/api/rest_api.py
@@ -1,0 +1,78 @@
+"""FastAPI-based RESTful service for Light-Go predictions.
+
+This module exposes two routes:
+ - ``/predict`` accepts POST requests with JSON ``{"input": ...}`` and
+   returns ``{"output": ...}`` using :func:`core.engine.predict`.
+ - ``/health`` is a simple GET route for health checks.
+
+It also enables CORS and can be run directly with Uvicorn.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+from core import engine as core_engine
+
+
+class PredictRequest(BaseModel):
+    """Request model for the ``/predict`` endpoint."""
+
+    input: Dict[str, Any]
+
+
+class PredictResponse(BaseModel):
+    """Response model returned by the ``/predict`` endpoint."""
+
+    output: Any
+
+
+app = FastAPI(title="Light-Go REST API")
+
+# Configure very permissive CORS by default
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.post("/predict", response_model=PredictResponse)
+async def predict(req: PredictRequest) -> PredictResponse:
+    """Run a prediction using :func:`core.engine.predict`.
+
+    Parameters
+    ----------
+    req:
+        Parsed request payload containing the ``input`` data.
+
+    Returns
+    -------
+    PredictResponse
+        The prediction wrapped in a ``PredictResponse`` model.
+    """
+
+    try:
+        result = core_engine.predict(req.input)
+    except Exception as exc:  # pragma: no cover - generic safety
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return PredictResponse(output=result)
+
+
+@app.get("/health")
+async def health() -> Dict[str, str]:
+    """Simple liveness probe."""
+
+    return {"status": "ok"}
+
+
+if __name__ == "__main__":  # pragma: no cover - manual start
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ qdrant-client>=1.5.0  # Qdrant 向量數據庫
 flask>=2.3.0          # REST API
 websockets>=11.0      # WebSocket API
 sgfmill>=1.1          # SGF parsing library
+fastapi>=0.100.0      # REST API server using FastAPI
+uvicorn>=0.22.0       # ASGI server for FastAPI
+httpx<0.24           # HTTP client for FastAPI tests

--- a/tests/unit_tests/rest_api.py
+++ b/tests/unit_tests/rest_api.py
@@ -1,0 +1,46 @@
+import pathlib
+import sys
+import asyncio
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+# Allow importing from project root
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from api import rest_api
+
+
+def _request(method: str, url: str, **kwargs) -> httpx.Response:
+    async def _call() -> httpx.Response:
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=rest_api.app), base_url="http://test") as client:
+            return await client.request(method, url, **kwargs)
+    return asyncio.run(_call())
+
+
+def test_health_endpoint() -> None:
+    response = _request("GET", "/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_predict_endpoint_success() -> None:
+    with patch("core.engine.predict", return_value={"move": "pass"}, create=True) as mock_pred:
+        payload = {"input": {"board": []}}
+        response = _request("POST", "/predict", json=payload)
+        assert response.status_code == 200
+        assert response.json() == {"output": {"move": "pass"}}
+        mock_pred.assert_called_once_with(payload["input"])
+
+
+def test_predict_invalid_payload() -> None:
+    response = _request("POST", "/predict", json={})
+    assert response.status_code == 422
+
+
+def test_predict_exception_handling() -> None:
+    with patch("core.engine.predict", side_effect=RuntimeError("boom"), create=True):
+        response = _request("POST", "/predict", json={"input": {"x": 1}})
+        assert response.status_code == 500
+        assert response.json()["detail"] == "boom"


### PR DESCRIPTION
## Summary
- implement `api/rest_api.py` providing prediction and health endpoints using FastAPI
- add unit tests for the REST API
- run REST API tests in GitHub Actions workflow
- include FastAPI and related packages in requirements

## Testing
- `pytest tests/unit_tests/engine.py tests/unit_tests/rest_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685e9a1512848326869bfd7df0d07497