### PR TITLE
Implement strategy loading method and CLI test

### DIFF
--- a/core/engine.py
+++ b/core/engine.py
@@ -140,6 +140,11 @@ class Engine:
         converted = self._convert_directory(data_dir)
         return [model.predict(sample) for sample in converted]
 
+    def load_strategy(self, name: str) -> Any:
+        """Load strategy ``name`` via :class:`StrategyManager`."""
+
+        return self.strategy_manager.load_strategy(name)
+
     # ------------------------------------------------------------------
     def decide_move(self, board: List[List[int]], color: str) -> tuple[int, int] | None:
         """Return a very naive move decision for ``board``.

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -86,3 +86,19 @@ def test_exception_logged(tmp_path):
         cli_main.main()
         log_exc.assert_called()
         assert 'Unhandled error' in log_exc.call_args.args[0]
+
+
+def test_strategy_argument_loads_strategy(tmp_path):
+    argv = [
+        'main.py',
+        '--mode', 'train',
+        '--data', 'dir',
+        '--output', str(tmp_path),
+        '--strategy', 'strat1'
+    ]
+    engine_mock = MagicMock()
+    engine_mock.strategy_manager.strategies_path = str(tmp_path)
+    engine_mock.train.return_value = 's1'
+    with patch.object(sys, 'argv', argv), patch('cli_main.Engine', return_value=engine_mock):
+        cli_main.main()
+        engine_mock.load_strategy.assert_called_with('strat1')


### PR DESCRIPTION
## Summary
- add `Engine.load_strategy()` wrapper
- ensure CLI uses `--strategy` without failure
- test passing `--strategy` argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f1a06bb588326aa2acb966de82a3a