### PR TITLE
Implement engine.predict and update API tests

### DIFF
--- a/tests/integration/test_rest_api.py
+++ b/tests/integration/test_rest_api.py
@@ -10,8 +10,7 @@ def test_health_and_predict_endpoints():
     assert resp.status_code == 200
     assert resp.json()['status'] == 'ok'
 
-    # mock model predict or use default which returns None
-    payload = {'input': {}}
+    payload = {'input': {'board': [[0]], 'color': 'black'}}
     pred = client.post('/predict', json=payload)
     assert pred.status_code == 200
-    assert 'output' in pred.json()
+    assert pred.json()['output'] is not None

--- a/tests/unit/test_websocket_api.py
+++ b/tests/unit/test_websocket_api.py
@@ -96,3 +96,15 @@ def test_disconnect_and_reconnect():
             ws2.close()
     finally:
         stop_server(server, thread)
+
+
+def test_predict_default_engine():
+    server, thread = start_server()
+    try:
+        ws = connect(f"ws://127.0.0.1:{PORT}/ws/predict")
+        ws.send(json.dumps({"input": {"board": [[0]], "color": "black"}}))
+        data = json.loads(ws.recv())
+        assert data["output"] is not None
+        ws.close()
+    finally:
+        stop_server(server, thread)


### PR DESCRIPTION
## Summary
- implement lazy-initialized `predict` in `core.engine`
- ensure REST API, WebSocket API and GTP interface work without patches
- add coverage for new global prediction logic
- fix empty board handling to always return a move

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f19ff30848326aa339f2e9250a16d