### PR TITLE
Fix CLI train output argument

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,10 +43,10 @@ def _load_config(path: str | None) -> Dict[str, Any]:
     return {}
 
 
-def _run_train(engine: Engine, data: str) -> str:
+def _run_train(engine: Engine, data: str, output_dir: str) -> str:
     """Run training task and return saved strategy name."""
 
-    strategy = engine.train(data)
+    strategy = engine.train(data, output_dir)
     logging.info("Saved strategy %s to %s", strategy, engine.strategy_manager.strategies_path)
     return strategy
 
@@ -93,7 +93,7 @@ def main() -> None:
         if args.mode == "train":
             if not args.data:
                 parser.error("--data is required for train mode")
-            name = _run_train(engine, args.data)
+            name = _run_train(engine, args.data, args.output)
             result_path = os.path.join(args.output, f"{name}.pkl")
             print(result_path)
         elif args.mode == "evaluate":

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -29,7 +29,7 @@ def test_argparse_train_calls_engine_train(tmp_path, capsys):
     with patch.object(sys, 'argv', argv), patch('cli_main.Engine', return_value=engine_mock) as engine_cls:
         cli_main.main()
         engine_cls.assert_called_with(str(tmp_path))
-        engine_mock.train.assert_called_with('data_dir')
+        engine_mock.train.assert_called_with('data_dir', str(tmp_path))
         assert capsys.readouterr().out.strip().endswith('s1.pkl')
 
 


### PR DESCRIPTION
## Summary
- pass output directory to `Engine.train` when running CLI
- update unit tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f10e2e7d08326b0e7ffa0a90f54cc