### PR TITLE
Remove sample_strategy references

### DIFF
--- a/core/auto_learner.py
+++ b/core/auto_learner.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, List, Optional
 from input.sgf_to_input import parse_sgf
 from core.liberty import count_liberties
 from .strategy_manager import StrategyManager
-from .sample_strategy import SampleGoStrategy
 
 
 class AutoLearner:
@@ -82,8 +81,7 @@ class AutoLearner:
         """Train from ``data_path`` and save the resulting strategy."""
         stats = self.train(data_path)
         name = self._next_strategy_name()
-        strategy = SampleGoStrategy(name=name, stats=stats)
-        self.manager.save_strategy(name, strategy)
+        self.manager.save_strategy(name, stats)
         self._scores[name] = 0.0
         self._allocation[name] = self._default_allocation()
         self._normalize_allocation()
@@ -98,8 +96,7 @@ class AutoLearner:
         """Register ``model`` (or ``data``) as a brand new strategy."""
 
         name = self._next_strategy_name()
-        strategy = SampleGoStrategy(name=name, stats=model or data)
-        self.manager.save_strategy(name, strategy)
+        self.manager.save_strategy(name, model or data)
         self._scores[name] = 0.0
         self._allocation[name] = self._default_allocation()
         self._normalize_allocation()

--- a/tests/unit/test_auto_learner.py
+++ b/tests/unit/test_auto_learner.py
@@ -7,7 +7,6 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
 
 from core.auto_learner import AutoLearner
 from core.strategy_manager import StrategyManager
-from core.sample_strategy import SampleGoStrategy
 
 
 def _build_manager(existing=None):
@@ -28,7 +27,7 @@ def test_discover_strategy_registers_new_strategy(tmp_path):
     manager.save_strategy.assert_called_once()
     args = manager.save_strategy.call_args[0]
     assert args[0] == new_name
-    assert isinstance(args[1], SampleGoStrategy)
+    assert isinstance(args[1], dict)
     assert new_name in learner._scores
     assert new_name in learner._allocation
     assert abs(sum(learner._allocation.values()) - 1.0) < 1e-6


### PR DESCRIPTION
## Summary
- clean up AutoLearner to stop using `SampleGoStrategy`
- adjust unit test to check for dictionaries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f9dc00d508326811b0818f296d77a