### PR TITLE
Refactor unit tests to follow CLAUDE.md compliance

### DIFF
--- a/tests/components/test_auto_learner.py
+++ b/tests/components/test_auto_learner.py
@@ -89,8 +89,8 @@ class TestGameStats:
         assert stats["black_stones"] == 10
         assert stats["white_stones"] == 10
 
-    @pytest.mark.parametrize("size", [5, 9, 13, 19])
-    def test_various_board_sizes(self, size):
+    @pytest.mark.parametrize("size", [5, 9, 13, 19], ids=["5x5", "9x9", "13x13", "19x19"])
+    def test_various_board_sizes(self, size: int):
         """Stats work for various board sizes."""
         board = [[0] * size for _ in range(size)]
         board[size // 2][size // 2] = 1
@@ -175,8 +175,8 @@ class TestAssignTraining:
         {"position_type": "middlegame", "liberties": 15},
         {"position_type": "endgame", "territory_diff": 5},
         {},
-    ])
-    def test_assign_with_various_features(self, auto_learner, features):
+    ], ids=["opening", "middlegame", "endgame", "empty"])
+    def test_assign_with_various_features(self, auto_learner, features: dict):
         """assign_training works with various feature types."""
         auto_learner.discover_strategy({})
 
@@ -299,8 +299,8 @@ class TestEdgeCases:
         except (TypeError, AttributeError):
             pass  # Expected for some implementations
 
-    @pytest.mark.parametrize("score", [100.0, -100.0, 0.0, 1.0])
-    def test_feedback_with_extreme_scores(self, auto_learner, score):
+    @pytest.mark.parametrize("score", [100.0, -100.0, 0.0, 1.0], ids=["max", "min", "zero", "one"])
+    def test_feedback_with_extreme_scores(self, auto_learner, score: float):
         """Feedback with extreme score values."""
         name = auto_learner.discover_strategy({})
 

--- a/tests/components/test_gtp_interface.py
+++ b/tests/components/test_gtp_interface.py
@@ -13,7 +13,7 @@ from api.gtp_interface import GTPServer
 
 
 @pytest.fixture
-def gtp_server():
+def gtp_server() -> GTPServer:
     """Return a fresh GTPServer instance."""
     return GTPServer()
 
@@ -90,8 +90,8 @@ class TestGTPBasicCommands:
 class TestGTPBoardsize:
     """Tests for boardsize command."""
 
-    @pytest.mark.parametrize("size", [9, 13, 19])
-    def test_boardsize_valid(self, gtp_server, size):
+    @pytest.mark.parametrize("size", [9, 13, 19], ids=["9x9", "13x13", "19x19"])
+    def test_boardsize_valid(self, gtp_server: GTPServer, size: int):
         """boardsize sets board size correctly."""
         response, should_quit = gtp_server.handle_boardsize([str(size)])
 
@@ -114,8 +114,12 @@ class TestGTPBoardsize:
 class TestGTPKomi:
     """Tests for komi command."""
 
-    @pytest.mark.parametrize("komi_str,expected", [("7.5", 7.5), ("6.5", 6.5), ("0", 0.0)])
-    def test_komi_valid(self, gtp_server, komi_str, expected):
+    @pytest.mark.parametrize(
+        "komi_str,expected",
+        [("7.5", 7.5), ("6.5", 6.5), ("0", 0.0)],
+        ids=["7.5", "6.5", "0.0"]
+    )
+    def test_komi_valid(self, gtp_server: GTPServer, komi_str: str, expected: float):
         """komi sets komi value correctly."""
         response, should_quit = gtp_server.handle_komi([komi_str])
 
@@ -138,8 +142,12 @@ class TestGTPKomi:
 class TestGTPPlay:
     """Tests for play command."""
 
-    @pytest.mark.parametrize("color,move", [("black", "D4"), ("white", "Q16"), ("black", "PASS")])
-    def test_play_valid(self, gtp_server, color, move):
+    @pytest.mark.parametrize(
+        "color,move",
+        [("black", "D4"), ("white", "Q16"), ("black", "PASS")],
+        ids=["black_d4", "white_q16", "black_pass"]
+    )
+    def test_play_valid(self, gtp_server: GTPServer, color: str, move: str):
         """play records move correctly."""
         response, should_quit = gtp_server.handle_play([color, move])
 
@@ -164,8 +172,8 @@ class TestGTPPlay:
 class TestGTPGenmove:
     """Tests for genmove command."""
 
-    @pytest.mark.parametrize("color", ["black", "white"])
-    def test_genmove_valid(self, gtp_server, color):
+    @pytest.mark.parametrize("color", ["black", "white"], ids=["black", "white"])
+    def test_genmove_valid(self, gtp_server: GTPServer, color: str):
         """genmove generates move for given color."""
         response, should_quit = gtp_server.handle_genmove([color])
 
@@ -211,13 +219,17 @@ class TestGTPDispatch:
 class TestGTPResponseFormat:
     """Tests for GTP response formatting."""
 
-    @pytest.mark.parametrize("prefix,ident,msg,expected_start", [
-        ("=", None, "result", "="),
-        ("?", None, "error msg", "?"),
-        ("=", "42", "result", "="),
-        ("=", None, "", "="),
-    ])
-    def test_format_response(self, prefix, ident, msg, expected_start):
+    @pytest.mark.parametrize(
+        "prefix,ident,msg,expected_start",
+        [
+            ("=", None, "result", "="),
+            ("?", None, "error msg", "?"),
+            ("=", "42", "result", "="),
+            ("=", None, "", "="),
+        ],
+        ids=["success", "error", "with_id", "empty_msg"]
+    )
+    def test_format_response(self, prefix: str, ident, msg: str, expected_start: str):
         """Response formatting follows GTP spec."""
         response = GTPServer._format_response(prefix, ident, msg)
 
@@ -257,8 +269,12 @@ class TestGTPIntegration:
 class TestEdgeCases:
     """Edge case tests for GTP server."""
 
-    @pytest.mark.parametrize("color", ["BLACK", "White", "WHITE", "black"])
-    def test_case_insensitive_color(self, gtp_server, color):
+    @pytest.mark.parametrize(
+        "color",
+        ["BLACK", "White", "WHITE", "black"],
+        ids=["upper_black", "mixed_white", "upper_white", "lower_black"]
+    )
+    def test_case_insensitive_color(self, gtp_server: GTPServer, color: str):
         """Colors are case insensitive."""
         gtp_server.handle_play([color, "D4"])
 

--- a/tests/components/test_sgf_parser.py
+++ b/tests/components/test_sgf_parser.py
@@ -322,8 +322,8 @@ class TestForbiddenMoves:
 class TestBoardSizes:
     """Tests for various board sizes."""
 
-    @pytest.mark.parametrize("size", [5, 9, 13, 19])
-    def test_parse_various_board_sizes(self, size):
+    @pytest.mark.parametrize("size", [5, 9, 13, 19], ids=["5x5", "9x9", "13x13", "19x19"])
+    def test_parse_various_board_sizes(self, size: int):
         """Parse games on various standard board sizes."""
         sgf = f"(;GM[1]FF[4]SZ[{size}];B[cc])"
         matrix, metadata, _ = parse_sgf(sgf, from_string=True)
@@ -336,8 +336,12 @@ class TestBoardSizes:
 class TestRulesets:
     """Tests for different ruleset handling."""
 
-    @pytest.mark.parametrize("ruleset", ["Chinese", "Japanese", "Korean", "AGA", "NZ"])
-    def test_parse_rulesets_case_insensitive(self, ruleset):
+    @pytest.mark.parametrize(
+        "ruleset",
+        ["Chinese", "Japanese", "Korean", "AGA", "NZ"],
+        ids=["chinese", "japanese", "korean", "aga", "nz"]
+    )
+    def test_parse_rulesets_case_insensitive(self, ruleset: str):
         """Rulesets should be parsed case-insensitively."""
         sgf = f"(;GM[1]FF[4]SZ[9]RU[{ruleset}];B[ee])"
         _, metadata, _ = parse_sgf(sgf, from_string=True)

--- a/tests/components/test_strategy_manager.py
+++ b/tests/components/test_strategy_manager.py
@@ -71,8 +71,8 @@ class TestCreateStrategy:
         {"total_black_stones": 0},
         {"total_black_stones": 100, "total_white_stones": 99},
         {"other_key": "value"},
-    ])
-    def test_accept_state_accepts_any_state(self, state):
+    ], ids=["empty", "zero_stones", "many_stones", "other_key"])
+    def test_accept_state_accepts_any_state(self, state: dict):
         """Default accept_state accepts any state."""
         strategy = create_strategy()
         assert strategy.accept_state(state) is True
@@ -808,8 +808,8 @@ class TestEdgeCases:
         "strategy.3",
         "UPPERCASE",
         "mixed_Case-123",
-    ])
-    def test_strategy_name_variations(self, strategy_manager, mock_strategy, name):
+    ], ids=["underscore", "dash", "dot", "uppercase", "mixed"])
+    def test_strategy_name_variations(self, strategy_manager, mock_strategy, name: str):
         """Strategy names with various characters."""
         strategy_manager.register_strategy(name, mock_strategy())
         assert name in strategy_manager.list_strategies()

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,46 +1,71 @@
-import pathlib
-import sys
+"""Unit tests for main application (app.py).
+
+Tests monitoring endpoints including health, performance, and logging.
+"""
+from __future__ import annotations
+
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
-# Add project root to path
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
-
+# Disable Gradio analytics before importing app
 os.environ.setdefault("GRADIO_ANALYTICS_ENABLED", "False")
 
+# Patch gradio.mount_gradio_app to avoid UI initialization
 with patch("gradio.mount_gradio_app", side_effect=lambda app, *a, **k: app):
-    import app
+    import app as app_module
 
 
-def test_monitoring_health_endpoint():
-    dash = MagicMock()
-    dash.api_status = AsyncMock(return_value={"status": "ok"})
-    with patch("app.health_check.build_default_dashboard", return_value=dash):
-        resp = app._client.get("/monitoring/health")
-        assert resp.status_code == 200
-        assert resp.json() == {"status": "ok"}
-        dash.api_status.assert_called_once()
+# ---------------------------------------------------------------------------
+# Test Classes
+# ---------------------------------------------------------------------------
+
+class TestMonitoringHealthEndpoint:
+    """Tests for monitoring health endpoint."""
+
+    def test_returns_dashboard_status(self):
+        """Health endpoint returns dashboard status."""
+        dash = MagicMock()
+        dash.api_status = AsyncMock(return_value={"status": "ok"})
+
+        with patch("app.health_check.build_default_dashboard", return_value=dash):
+            resp = app_module._client.get("/monitoring/health")
+
+            assert resp.status_code == 200
+            assert resp.json() == {"status": "ok"}
+            dash.api_status.assert_called_once()
 
 
-def test_monitoring_performance_endpoint():
-    class Dummy:
-        def __enter__(self):
-            return self
-        def __exit__(self, exc_type, exc, tb):
-            return False
-        stats = {"cpu": 1}
-    with patch("app.performance.PerformanceMonitor", return_value=Dummy()):
-        resp = app._client.get("/monitoring/performance")
-        assert resp.status_code == 200
-        assert resp.json() == {"cpu": 1}
+class TestMonitoringPerformanceEndpoint:
+    """Tests for monitoring performance endpoint."""
+
+    def test_returns_performance_stats(self):
+        """Performance endpoint returns stats from monitor."""
+        class Dummy:
+            def __enter__(self):
+                return self
+            def __exit__(self, exc_type, exc, tb):
+                return False
+            stats = {"cpu": 1}
+
+        with patch("app.performance.PerformanceMonitor", return_value=Dummy()):
+            resp = app_module._client.get("/monitoring/performance")
+
+            assert resp.status_code == 200
+            assert resp.json() == {"cpu": 1}
 
 
-def test_monitoring_logging_endpoint():
-    q = MagicMock()
-    q.summary.return_value = {"duration": 1}
-    q.logs = [1]
-    with patch("app.log_utils.PerformanceLogQuery", return_value=q):
-        resp = app._client.get("/monitoring/logging", params={"file": "f.json"})
-        q.load_logs.assert_called_with("f.json")
-        assert resp.status_code == 200
-        assert resp.json() == {"summary": {"duration": 1}, "entries": [1]}
+class TestMonitoringLoggingEndpoint:
+    """Tests for monitoring logging endpoint."""
+
+    def test_returns_log_summary(self):
+        """Logging endpoint returns summary and entries."""
+        q = MagicMock()
+        q.summary.return_value = {"duration": 1}
+        q.logs = [1]
+
+        with patch("app.log_utils.PerformanceLogQuery", return_value=q):
+            resp = app_module._client.get("/monitoring/logging", params={"file": "f.json"})
+
+            q.load_logs.assert_called_with("f.json")
+            assert resp.status_code == 200
+            assert resp.json() == {"summary": {"duration": 1}, "entries": [1]}

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -1,15 +1,24 @@
+"""Unit tests for Engine (core/engine.py).
+
+Tests engine initialization, training, evaluation, and prediction
+using mock implementations.
+"""
+from __future__ import annotations
+
 import os
-import pathlib
-import sys
+from pathlib import Path
 from unittest.mock import Mock, patch
 
-# Add project root to path
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+import pytest
 
 from core.engine import Engine
 
 
-def _create_engine(tmp_path: pathlib.Path):
+# ---------------------------------------------------------------------------
+# Helper Functions
+# ---------------------------------------------------------------------------
+
+def _create_engine(tmp_path: Path):
     """Create an Engine with mocks for its dependencies."""
     sm_patch = patch('core.engine.StrategyManager')
     al_patch = patch('core.engine.AutoLearner')
@@ -21,162 +30,194 @@ def _create_engine(tmp_path: pathlib.Path):
     return engine, sm_inst, al_inst, MockSM, MockAL
 
 
-def test_engine_initialization(tmp_path: pathlib.Path):
-    engine, sm_inst, al_inst, MockSM, MockAL = _create_engine(tmp_path)
+# ---------------------------------------------------------------------------
+# Test Classes
+# ---------------------------------------------------------------------------
 
-    MockSM.assert_called_with(os.path.join(str(tmp_path), 'strategies'))
-    MockAL.assert_called_with(sm_inst)
-    assert engine.strategy_manager is sm_inst
-    assert engine.auto_learner is al_inst
+class TestEngineInitialization:
+    """Tests for Engine initialization."""
 
+    def test_creates_strategy_manager(self, tmp_path: Path):
+        """Engine creates StrategyManager with correct path."""
+        engine, sm_inst, al_inst, MockSM, MockAL = _create_engine(tmp_path)
 
-def test_engine_train(tmp_path: pathlib.Path):
-    engine, sm_inst, al_inst, _, _ = _create_engine(tmp_path)
-    data_dir = tmp_path / 'data'
-    out_dir = tmp_path / 'out'
-    data_dir.mkdir()
-    out_dir.mkdir()
-
-    with patch.object(Engine, '_convert_directory', return_value=['d1']) as conv, \
-         patch('core.engine.GoAIModel') as MockModel:
-        model_inst = Mock()
-        MockModel.return_value = model_inst
-        al_inst.train_and_save.return_value = 's1'
-
-        name = engine.train(str(data_dir), str(out_dir))
-
-        conv.assert_called_once_with(str(data_dir))
-        al_inst.train_and_save.assert_called_once_with(str(data_dir))
-        model_inst.train.assert_called_once_with(['d1'])
-        model_inst.save_pretrained.assert_called_once_with(os.path.join(str(out_dir), 's1.pt'))
-        assert name == 's1'
+        MockSM.assert_called_with(os.path.join(str(tmp_path), 'strategies'))
+        MockAL.assert_called_with(sm_inst)
+        assert engine.strategy_manager is sm_inst
+        assert engine.auto_learner is al_inst
 
 
-def test_engine_train_npz(tmp_path: pathlib.Path):
-    engine, sm_inst, al_inst, _, _ = _create_engine(tmp_path)
-    data_dir = tmp_path / 'data'
-    out_dir = tmp_path / 'out'
-    data_dir.mkdir()
-    out_dir.mkdir()
-    npz_file = data_dir / 'd.npz'
-    npz_file.touch()
+class TestEngineTrain:
+    """Tests for Engine.train() method."""
 
-    with patch('numpy.load') as np_load, \
-         patch('core.engine.GoAIModel') as MockModel, \
-         patch('input.katago_to_input.process_katago_lines', return_value=['d1']) as proc:
-        class Dummy:
-            files = ['arr']
-            def __getitem__(self, k):
-                return ['{}']
-        np_load.return_value = Dummy()
-        model_inst = Mock()
-        MockModel.return_value = model_inst
-        al_inst.train_and_save.return_value = 's1'
+    def test_train_calls_convert_and_model(self, tmp_path: Path):
+        """train() calls convert, model.train, and saves model."""
+        engine, sm_inst, al_inst, _, _ = _create_engine(tmp_path)
+        data_dir = tmp_path / 'data'
+        output_dir = tmp_path / 'out'
+        data_dir.mkdir()
+        output_dir.mkdir()
 
-        name = engine.train_npz_directory(str(data_dir), str(out_dir))
+        with patch.object(Engine, '_convert_directory', return_value=['d1']) as conv, \
+             patch('core.engine.GoAIModel') as MockModel:
+            model_inst = Mock()
+            MockModel.return_value = model_inst
+            al_inst.train_and_save.return_value = 's1'
 
-        proc.assert_called()
-        model_inst.train.assert_called_with(['d1'])
-        model_inst.save_pretrained.assert_called_once_with(os.path.join(str(out_dir), 's1.pt'))
-        assert name == 's1'
+            name = engine.train(str(data_dir), str(output_dir))
 
+            conv.assert_called_once_with(str(data_dir))
+            al_inst.train_and_save.assert_called_once_with(str(data_dir))
+            model_inst.train.assert_called_once_with(['d1'])
+            model_inst.save_pretrained.assert_called_once_with(
+                os.path.join(str(output_dir), 's1.pt')
+            )
+            assert name == 's1'
 
-def test_engine_evaluate(tmp_path: pathlib.Path):
-    engine, sm_inst, al_inst, _, _ = _create_engine(tmp_path)
-    data_dir = tmp_path / 'data'
-    out_dir = tmp_path / 'out'
-    data_dir.mkdir()
-    out_dir.mkdir()
+    def test_train_npz_directory(self, tmp_path: Path):
+        """train_npz_directory processes NPZ files correctly."""
+        engine, sm_inst, al_inst, _, _ = _create_engine(tmp_path)
+        data_dir = tmp_path / 'data'
+        output_dir = tmp_path / 'out'
+        data_dir.mkdir()
+        output_dir.mkdir()
+        npz_file = data_dir / 'd.npz'
+        npz_file.touch()
 
-    sm_inst.list_strategies.return_value = ['a', 'b']
-    with patch.object(Engine, '_convert_directory', return_value=['c1']) as conv, \
-         patch.object(Engine, '_fuse_predictions', return_value=['fused']) as fuse, \
-         patch('core.engine.GoAIModel') as MockModel:
-        model_inst = Mock()
-        MockModel.from_pretrained.return_value = model_inst
-        model_inst.predict.return_value = 'p'
+        with patch('numpy.load') as np_load, \
+             patch('core.engine.GoAIModel') as MockModel, \
+             patch('input.katago_to_input.process_katago_lines', return_value=['d1']) as proc:
+            class Dummy:
+                files = ['arr']
+                def __getitem__(self, k):
+                    return ['{}']
+            np_load.return_value = Dummy()
+            model_inst = Mock()
+            MockModel.return_value = model_inst
+            al_inst.train_and_save.return_value = 's1'
 
-        metrics = engine.evaluate(str(data_dir), str(out_dir))
+            name = engine.train_npz_directory(str(data_dir), str(output_dir))
 
-        conv.assert_called_once_with(str(data_dir))
-        assert MockModel.from_pretrained.call_count == 2
-        model_inst.predict.assert_called_with('c1')
-        fuse.assert_called_once()
-        al_inst.train.assert_called_once_with(str(data_dir))
-        assert metrics == {'samples': 1, 'strategies_tested': 2}
-
-
-def test_engine_play_latest(tmp_path: pathlib.Path):
-    engine, sm_inst, _, _, _ = _create_engine(tmp_path)
-    data_dir = tmp_path / 'data'
-    out_dir = tmp_path / 'out'
-    data_dir.mkdir()
-    out_dir.mkdir()
-
-    sm_inst.list_strategies.return_value = ['a', 'b']
-    with patch.object(Engine, '_convert_directory', return_value=['c1']) as conv, \
-         patch('core.engine.GoAIModel') as MockModel:
-        model_inst = Mock()
-        MockModel.from_pretrained.return_value = model_inst
-        model_inst.predict.return_value = 'r'
-
-        result = engine.play(str(data_dir), str(out_dir))
-
-        conv.assert_called_once_with(str(data_dir))
-        MockModel.from_pretrained.assert_called_once_with(os.path.join(str(out_dir), 'b.pt'))
-        model_inst.predict.assert_called_once_with('c1')
-        assert result == ['r']
+            proc.assert_called()
+            model_inst.train.assert_called_with(['d1'])
+            model_inst.save_pretrained.assert_called_once_with(
+                os.path.join(str(output_dir), 's1.pt')
+            )
+            assert name == 's1'
 
 
-def test_engine_play_specific_strategy(tmp_path: pathlib.Path):
-    engine, sm_inst, _, _, _ = _create_engine(tmp_path)
-    data_dir = tmp_path / 'data'
-    out_dir = tmp_path / 'out'
-    data_dir.mkdir()
-    out_dir.mkdir()
+class TestEngineEvaluate:
+    """Tests for Engine.evaluate() method."""
 
-    sm_inst.list_strategies.return_value = ['a', 'b']
-    with patch.object(Engine, '_convert_directory', return_value=['c1']) as conv, \
-         patch('core.engine.GoAIModel') as MockModel:
-        model_inst = Mock()
-        MockModel.from_pretrained.return_value = model_inst
-        model_inst.predict.return_value = 'r'
+    def test_evaluate_returns_metrics(self, tmp_path: Path):
+        """evaluate() returns metrics dict."""
+        engine, sm_inst, al_inst, _, _ = _create_engine(tmp_path)
+        data_dir = tmp_path / 'data'
+        output_dir = tmp_path / 'out'
+        data_dir.mkdir()
+        output_dir.mkdir()
 
-        result = engine.play(str(data_dir), str(out_dir), strategy='a')
+        sm_inst.list_strategies.return_value = ['a', 'b']
+        with patch.object(Engine, '_convert_directory', return_value=['c1']) as conv, \
+             patch.object(Engine, '_fuse_predictions', return_value=['fused']) as fuse, \
+             patch('core.engine.GoAIModel') as MockModel:
+            model_inst = Mock()
+            MockModel.from_pretrained.return_value = model_inst
+            model_inst.predict.return_value = 'p'
 
-        conv.assert_called_once_with(str(data_dir))
-        MockModel.from_pretrained.assert_called_once_with(os.path.join(str(out_dir), 'a.pt'))
-        model_inst.predict.assert_called_once_with('c1')
-        assert result == ['r']
+            metrics = engine.evaluate(str(data_dir), str(output_dir))
 
-
-def test_predict_lazy_engine(tmp_path: pathlib.Path, monkeypatch):
-    import core.engine as engine_mod
-    monkeypatch.setattr(engine_mod, "_engine_instance", None, raising=False)
-    engine_inst = Mock()
-    engine_inst.decide_move.return_value = (0, 0)
-    engine_cls = Mock(return_value=engine_inst)
-    monkeypatch.setattr(engine_mod, "Engine", engine_cls)
-    monkeypatch.setenv("LIGHTGO_MODEL_DIR", str(tmp_path))
-
-    result1 = engine_mod.predict({"board": [[0]], "color": "black"})
-    result2 = engine_mod.predict({"board": [[0]], "color": "black"})
-
-    engine_cls.assert_called_once_with(str(tmp_path))
-    assert result1 == (0, 0)
-    assert result2 == (0, 0)
+            conv.assert_called_once_with(str(data_dir))
+            assert MockModel.from_pretrained.call_count == 2
+            model_inst.predict.assert_called_with('c1')
+            fuse.assert_called_once()
+            al_inst.train.assert_called_once_with(str(data_dir))
+            assert metrics == {'samples': 1, 'strategies_tested': 2}
 
 
-def test_predict_empty_move_list(monkeypatch):
-    import core.engine as engine_mod
-    engine_inst = Mock()
-    engine_mod._engine_instance = engine_inst
-    engine_inst.decide_move.return_value = (1, 2)
+class TestEnginePlay:
+    """Tests for Engine.play() method."""
 
-    result = engine_mod.predict({"board": [], "color": "black", "size": 5})
+    def test_play_uses_latest_strategy(self, tmp_path: Path):
+        """play() uses the latest strategy by default."""
+        engine, sm_inst, _, _, _ = _create_engine(tmp_path)
+        data_dir = tmp_path / 'data'
+        output_dir = tmp_path / 'out'
+        data_dir.mkdir()
+        output_dir.mkdir()
 
-    board_arg, color_arg = engine_inst.decide_move.call_args[0]
-    assert len(board_arg) == 5
-    assert len(board_arg[0]) == 5
-    assert color_arg == "black"
-    assert result == (1, 2)
+        sm_inst.list_strategies.return_value = ['a', 'b']
+        with patch.object(Engine, '_convert_directory', return_value=['c1']) as conv, \
+             patch('core.engine.GoAIModel') as MockModel:
+            model_inst = Mock()
+            MockModel.from_pretrained.return_value = model_inst
+            model_inst.predict.return_value = 'r'
+
+            result = engine.play(str(data_dir), str(output_dir))
+
+            conv.assert_called_once_with(str(data_dir))
+            MockModel.from_pretrained.assert_called_once_with(
+                os.path.join(str(output_dir), 'b.pt')
+            )
+            model_inst.predict.assert_called_once_with('c1')
+            assert result == ['r']
+
+    def test_play_with_specific_strategy(self, tmp_path: Path):
+        """play() uses specified strategy when provided."""
+        engine, sm_inst, _, _, _ = _create_engine(tmp_path)
+        data_dir = tmp_path / 'data'
+        output_dir = tmp_path / 'out'
+        data_dir.mkdir()
+        output_dir.mkdir()
+
+        sm_inst.list_strategies.return_value = ['a', 'b']
+        with patch.object(Engine, '_convert_directory', return_value=['c1']) as conv, \
+             patch('core.engine.GoAIModel') as MockModel:
+            model_inst = Mock()
+            MockModel.from_pretrained.return_value = model_inst
+            model_inst.predict.return_value = 'r'
+
+            result = engine.play(str(data_dir), str(output_dir), strategy='a')
+
+            conv.assert_called_once_with(str(data_dir))
+            MockModel.from_pretrained.assert_called_once_with(
+                os.path.join(str(output_dir), 'a.pt')
+            )
+            model_inst.predict.assert_called_once_with('c1')
+            assert result == ['r']
+
+
+class TestModuleLevelPredict:
+    """Tests for module-level predict() function."""
+
+    def test_lazy_engine_initialization(self, tmp_path: Path, monkeypatch):
+        """predict() lazily initializes engine singleton."""
+        import core.engine as engine_mod
+        monkeypatch.setattr(engine_mod, "_engine_instance", None, raising=False)
+        engine_inst = Mock()
+        engine_inst.decide_move.return_value = (0, 0)
+        engine_cls = Mock(return_value=engine_inst)
+        monkeypatch.setattr(engine_mod, "Engine", engine_cls)
+        monkeypatch.setenv("LIGHTGO_MODEL_DIR", str(tmp_path))
+
+        result1 = engine_mod.predict({"board": [[0]], "color": "black"})
+        result2 = engine_mod.predict({"board": [[0]], "color": "black"})
+
+        engine_cls.assert_called_once_with(str(tmp_path))
+        assert result1 == (0, 0)
+        assert result2 == (0, 0)
+
+    def test_predict_with_empty_move_list(self, monkeypatch):
+        """predict() handles empty move list by creating board from size."""
+        import core.engine as engine_mod
+        engine_inst = Mock()
+        engine_mod._engine_instance = engine_inst
+        engine_inst.decide_move.return_value = (1, 2)
+
+        result = engine_mod.predict({"board": [], "color": "black", "size": 5})
+
+        board_arg, color_arg = engine_inst.decide_move.call_args[0]
+        assert len(board_arg) == 5
+        assert len(board_arg[0]) == 5
+        assert color_arg == "black"
+        assert result == (1, 2)

--- a/tests/unit/test_gtp_interface.py
+++ b/tests/unit/test_gtp_interface.py
@@ -72,20 +72,20 @@ class TestGTPBasicCommands:
 class TestGTPBoardConfiguration:
     """Tests for board configuration commands."""
 
-    @pytest.mark.parametrize("board_size", [9, 13, 19])
-    def test_boardsize(self, gtp_server: GTPServer, board_size: int):
+    @pytest.mark.parametrize("size", [9, 13, 19], ids=["9x9", "13x13", "19x19"])
+    def test_boardsize(self, gtp_server: GTPServer, size: int):
         """boardsize sets board size correctly."""
-        response, should_quit = gtp_server.handle_boardsize([str(board_size)])
+        response, should_quit = gtp_server.handle_boardsize([str(size)])
 
-        assert gtp_server.board_size == board_size
+        assert gtp_server.board_size == size
         assert should_quit is False
 
-    @pytest.mark.parametrize("komi_value", [0.0, 6.5, 7.5])
-    def test_komi(self, gtp_server: GTPServer, komi_value: float):
+    @pytest.mark.parametrize("komi", [0.0, 6.5, 7.5], ids=["0.0", "6.5", "7.5"])
+    def test_komi(self, gtp_server: GTPServer, komi: float):
         """komi sets komi value correctly."""
-        response, should_quit = gtp_server.handle_komi([str(komi_value)])
+        response, should_quit = gtp_server.handle_komi([str(komi)])
 
-        assert gtp_server.komi == komi_value
+        assert gtp_server.komi == komi
         assert should_quit is False
 
     def test_clear_board(self, gtp_server: GTPServer):
@@ -106,7 +106,7 @@ class TestGTPGameplay:
         ("black", "D4"),
         ("white", "Q16"),
         ("black", "PASS"),
-    ])
+    ], ids=["black_d4", "white_q16", "black_pass"])
     def test_play(self, gtp_server: GTPServer, color: str, move: str):
         """play records moves correctly."""
         response, should_quit = gtp_server.handle_play([color, move])
@@ -114,7 +114,7 @@ class TestGTPGameplay:
         assert (color, move) in gtp_server.moves
         assert should_quit is False
 
-    @pytest.mark.parametrize("color", ["black", "white"])
+    @pytest.mark.parametrize("color", ["black", "white"], ids=["black", "white"])
     def test_genmove(self, gtp_server: GTPServer, color: str):
         """genmove generates a valid move using real engine."""
         gtp_server.handle_boardsize(["9"])

--- a/tests/unit/test_katago_to_input.py
+++ b/tests/unit/test_katago_to_input.py
@@ -2,32 +2,33 @@
 
 Tests coordinate conversion and file processing for KataGo format data.
 """
+from __future__ import annotations
+
 import json
-import pathlib
-import sys
-from unittest.mock import patch, mock_open
+from unittest.mock import mock_open, patch
 
 import pytest
-
-# Add project root to path
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
 
 from input.katago_to_input import katago_to_coords, process_katago_file
 
 
+# ---------------------------------------------------------------------------
+# Test Classes
+# ---------------------------------------------------------------------------
+
 class TestKatagoToCoords:
     """Tests for katago_to_coords() function."""
 
-    @pytest.mark.parametrize("move,board_size,expected", [
+    @pytest.mark.parametrize("move,size,expected", [
         ("A19", 19, (0, 0)),
         ("T1", 19, (18, 18)),
         ("K10", 19, (9, 9)),
     ], ids=["top_left", "bottom_right", "center"])
-    def test_valid_coordinates(self, move, board_size, expected):
+    def test_valid_coordinates(self, move: str, size: int, expected: tuple):
         """Valid move strings convert to correct coordinates."""
-        assert katago_to_coords(move, board_size) == expected
+        assert katago_to_coords(move, size) == expected
 
-    @pytest.mark.parametrize("move,board_size", [
+    @pytest.mark.parametrize("move,size", [
         ("PASS", 19),
         ("A20", 19),     # Out of bounds
         ("Z10", 19),     # Invalid column
@@ -35,9 +36,9 @@ class TestKatagoToCoords:
         (None, 19),      # None input
         (123, 19),       # Wrong type
     ], ids=["pass", "out_of_bounds", "invalid_col", "incomplete", "none", "wrong_type"])
-    def test_invalid_coordinates_return_none(self, move, board_size):
+    def test_invalid_coordinates_return_none(self, move, size: int):
         """Invalid move strings return None."""
-        assert katago_to_coords(move, board_size) is None
+        assert katago_to_coords(move, size) is None
 
 
 class TestProcessKatagoFile:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,140 +1,202 @@
-import pathlib
-import sys
-from unittest.mock import MagicMock, patch
-import numpy as np
+"""Unit tests for CLI entry point (main.py).
 
-# Put project root on sys.path so we can load the CLI module
-ROOT = pathlib.Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(ROOT))
+Tests command-line argument parsing and mode execution.
+
+Note: main.py is loaded via importlib since it's a CLI entry point,
+not a standard module.
+"""
+from __future__ import annotations
 
 import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
+import numpy as np
+import pytest
+
+# Load main.py as a module using importlib
+ROOT = Path(__file__).resolve().parents[2]
 spec = importlib.util.spec_from_file_location("cli_main", ROOT / "main.py")
 cli_main = importlib.util.module_from_spec(spec)
 sys.modules["cli_main"] = cli_main
 spec.loader.exec_module(cli_main)
 
-import pytest
 
+# ---------------------------------------------------------------------------
+# Test Classes
+# ---------------------------------------------------------------------------
 
-def test_argparse_train_calls_engine_train(tmp_path, capsys):
-    argv = [
-        'main.py',
-        '--mode', 'train',
-        '--data', 'data_dir',
-        '--output', str(tmp_path)
-    ]
-    engine_mock = MagicMock()
-    engine_mock.strategy_manager.strategies_path = str(tmp_path)
-    engine_mock.train.return_value = 's1'
-    with patch.object(sys, 'argv', argv), \
-         patch('cli_main.detect_data_type', return_value='sgf'), \
-         patch('cli_main.Engine', return_value=engine_mock) as engine_cls:
-        cli_main.main()
-        engine_cls.assert_called_with(str(tmp_path))
-        engine_mock.train.assert_called_with('data_dir', str(tmp_path))
-        assert capsys.readouterr().out.strip().endswith('s1.pkl')
+class TestTrainMode:
+    """Tests for train mode."""
 
+    def test_train_sgf_calls_engine_train(self, tmp_path: Path, capsys):
+        """Train mode with SGF data calls engine.train()."""
+        argv = [
+            'main.py',
+            '--mode', 'train',
+            '--data', 'data_dir',
+            '--output', str(tmp_path)
+        ]
+        engine_mock = MagicMock()
+        engine_mock.strategy_manager.strategies_path = str(tmp_path)
+        engine_mock.train.return_value = 's1'
 
-def test_evaluate_calls_auto_learner(tmp_path, capsys):
-    argv = [
-        'main.py',
-        '--mode', 'evaluate',
-        '--data', 'eval_dir',
-        '--output', str(tmp_path)
-    ]
-    engine_mock = MagicMock()
-    engine_mock.strategy_manager.strategies_path = str(tmp_path)
-    engine_mock.auto_learner.train.return_value = {'score': 1}
-    with patch.object(sys, 'argv', argv), patch('cli_main.Engine', return_value=engine_mock):
-        cli_main.main()
-        engine_mock.auto_learner.train.assert_called_with('eval_dir')
-        assert 'score' in capsys.readouterr().out
-
-
-def test_play_calls_decide_move(tmp_path, capsys):
-    argv = [
-        'main.py',
-        '--mode', 'play',
-        '--data', 'game.sgf',
-        '--output', str(tmp_path)
-    ]
-    engine_mock = MagicMock()
-    engine_mock.strategy_manager.strategies_path = str(tmp_path)
-    engine_mock.decide_move.return_value = (3, 3)
-    with patch.object(sys, 'argv', argv), \
-         patch('cli_main.Engine', return_value=engine_mock), \
-         patch('input.sgf_to_input.parse_sgf', return_value=([[0]], {'next_move': 'black'}, None)) as parser:
-        cli_main.main()
-        parser.assert_called_with('game.sgf')
-        engine_mock.decide_move.assert_called_with([[0]], 'black')
-        assert '(3, 3)' in capsys.readouterr().out
-
-
-def test_missing_data_errors(tmp_path):
-    argv = ['main.py', '--mode', 'train', '--output', str(tmp_path)]
-    with patch.object(sys, 'argv', argv), patch('cli_main.Engine'):
-        with pytest.raises(SystemExit):
+        with patch.object(sys, 'argv', argv), \
+             patch('cli_main.detect_data_type', return_value='sgf'), \
+             patch('cli_main.Engine', return_value=engine_mock) as engine_cls:
             cli_main.main()
 
+            engine_cls.assert_called_with(str(tmp_path))
+            engine_mock.train.assert_called_with('data_dir', str(tmp_path))
+            assert capsys.readouterr().out.strip().endswith('s1.pkl')
 
-def test_exception_logged(tmp_path):
-    argv = ['main.py', '--mode', 'train', '--data', 'dir', '--output', str(tmp_path)]
-    engine_mock = MagicMock()
-    engine_mock.strategy_manager.strategies_path = str(tmp_path)
-    engine_mock.train.side_effect = RuntimeError('boom')
-    with patch.object(sys, 'argv', argv), \
-         patch('cli_main.detect_data_type', return_value='sgf'), \
-         patch('cli_main.Engine', return_value=engine_mock), \
-         patch('logging.exception') as log_exc:
-        cli_main.main()
-        log_exc.assert_called()
-        assert 'Unhandled error' in log_exc.call_args.args[0]
+    def test_train_npz_calls_engine(self, tmp_path: Path, capsys):
+        """Train mode with NPZ data calls engine.train_npz_directory()."""
+        argv = [
+            'main.py', '--mode', 'train',
+            '--data', str(tmp_path),
+            '--output', str(tmp_path / 'out')
+        ]
+        (tmp_path / 'out').mkdir()
+        np.savez(tmp_path / 'd.npz', data=['{}'])
+        engine_mock = MagicMock()
+        engine_mock.strategy_manager.strategies_path = str(tmp_path)
+        engine_mock.train_npz_directory.return_value = 's1'
 
+        with patch.object(sys, 'argv', argv), \
+             patch('cli_main.Engine', return_value=engine_mock) as engine_cls:
+            cli_main.main()
 
-def test_strategy_argument_loads_strategy(tmp_path):
-    argv = [
-        'main.py',
-        '--mode', 'train',
-        '--data', 'dir',
-        '--output', str(tmp_path),
-        '--strategy', 'strat1'
-    ]
-    engine_mock = MagicMock()
-    engine_mock.strategy_manager.strategies_path = str(tmp_path)
-    engine_mock.train.return_value = 's1'
-    with patch.object(sys, 'argv', argv), \
-         patch('cli_main.detect_data_type', return_value='sgf'), \
-         patch('cli_main.Engine', return_value=engine_mock):
-        cli_main.main()
-        engine_mock.load_strategy.assert_called_with('strat1')
+            engine_cls.assert_called_with(str(tmp_path / 'out'))
+            engine_mock.train_npz_directory.assert_called_with(
+                str(tmp_path), str(tmp_path / 'out')
+            )
+            assert capsys.readouterr().out.strip().endswith('s1.pkl')
 
 
-def test_detect_data_type(tmp_path):
-    sgf_file = tmp_path / 'a.sgf'
-    sgf_file.write_text('')
-    assert cli_main.detect_data_type(str(tmp_path)) == 'sgf'
-    sgf_file.unlink()
-    npz_path = tmp_path / 'b.npz'
-    np.savez(npz_path, data=['{}'])
-    assert cli_main.detect_data_type(str(tmp_path)) == 'npz'
-    (tmp_path / 'c.sgf').write_text('')
-    with pytest.raises(ValueError):
-        cli_main.detect_data_type(str(tmp_path))
+class TestEvaluateMode:
+    """Tests for evaluate mode."""
+
+    def test_calls_auto_learner_train(self, tmp_path: Path, capsys):
+        """Evaluate mode calls auto_learner.train()."""
+        argv = [
+            'main.py',
+            '--mode', 'evaluate',
+            '--data', 'eval_dir',
+            '--output', str(tmp_path)
+        ]
+        engine_mock = MagicMock()
+        engine_mock.strategy_manager.strategies_path = str(tmp_path)
+        engine_mock.auto_learner.train.return_value = {'score': 1}
+
+        with patch.object(sys, 'argv', argv), \
+             patch('cli_main.Engine', return_value=engine_mock):
+            cli_main.main()
+
+            engine_mock.auto_learner.train.assert_called_with('eval_dir')
+            assert 'score' in capsys.readouterr().out
 
 
-def test_argparse_train_npz_calls_engine(tmp_path, capsys):
-    argv = [
-        'main.py', '--mode', 'train', '--data', str(tmp_path), '--output', str(tmp_path / 'out')
-    ]
-    (tmp_path / 'out').mkdir()
-    np.savez(tmp_path / 'd.npz', data=['{}'])
-    engine_mock = MagicMock()
-    engine_mock.strategy_manager.strategies_path = str(tmp_path)
-    engine_mock.train_npz_directory.return_value = 's1'
-    with patch.object(sys, 'argv', argv), \
-         patch('cli_main.Engine', return_value=engine_mock) as engine_cls:
-        cli_main.main()
-        engine_cls.assert_called_with(str(tmp_path / 'out'))
-        engine_mock.train_npz_directory.assert_called_with(str(tmp_path), str(tmp_path / 'out'))
-        assert capsys.readouterr().out.strip().endswith('s1.pkl')
+class TestPlayMode:
+    """Tests for play mode."""
+
+    def test_calls_decide_move(self, tmp_path: Path, capsys):
+        """Play mode calls engine.decide_move()."""
+        argv = [
+            'main.py',
+            '--mode', 'play',
+            '--data', 'game.sgf',
+            '--output', str(tmp_path)
+        ]
+        engine_mock = MagicMock()
+        engine_mock.strategy_manager.strategies_path = str(tmp_path)
+        engine_mock.decide_move.return_value = (3, 3)
+
+        with patch.object(sys, 'argv', argv), \
+             patch('cli_main.Engine', return_value=engine_mock), \
+             patch('input.sgf_to_input.parse_sgf',
+                   return_value=([[0]], {'next_move': 'black'}, None)) as parser:
+            cli_main.main()
+
+            parser.assert_called_with('game.sgf')
+            engine_mock.decide_move.assert_called_with([[0]], 'black')
+            assert '(3, 3)' in capsys.readouterr().out
+
+
+class TestArgumentValidation:
+    """Tests for argument validation."""
+
+    def test_missing_data_errors(self, tmp_path: Path):
+        """Missing --data argument causes SystemExit."""
+        argv = ['main.py', '--mode', 'train', '--output', str(tmp_path)]
+
+        with patch.object(sys, 'argv', argv), patch('cli_main.Engine'):
+            with pytest.raises(SystemExit):
+                cli_main.main()
+
+    def test_strategy_argument_loads_strategy(self, tmp_path: Path):
+        """--strategy argument triggers load_strategy()."""
+        argv = [
+            'main.py',
+            '--mode', 'train',
+            '--data', 'dir',
+            '--output', str(tmp_path),
+            '--strategy', 'strat1'
+        ]
+        engine_mock = MagicMock()
+        engine_mock.strategy_manager.strategies_path = str(tmp_path)
+        engine_mock.train.return_value = 's1'
+
+        with patch.object(sys, 'argv', argv), \
+             patch('cli_main.detect_data_type', return_value='sgf'), \
+             patch('cli_main.Engine', return_value=engine_mock):
+            cli_main.main()
+
+            engine_mock.load_strategy.assert_called_with('strat1')
+
+
+class TestErrorHandling:
+    """Tests for error handling."""
+
+    def test_exception_logged(self, tmp_path: Path):
+        """Runtime exceptions are logged."""
+        argv = ['main.py', '--mode', 'train', '--data', 'dir', '--output', str(tmp_path)]
+        engine_mock = MagicMock()
+        engine_mock.strategy_manager.strategies_path = str(tmp_path)
+        engine_mock.train.side_effect = RuntimeError('boom')
+
+        with patch.object(sys, 'argv', argv), \
+             patch('cli_main.detect_data_type', return_value='sgf'), \
+             patch('cli_main.Engine', return_value=engine_mock), \
+             patch('logging.exception') as log_exc:
+            cli_main.main()
+
+            log_exc.assert_called()
+            assert 'Unhandled error' in log_exc.call_args.args[0]
+
+
+class TestDetectDataType:
+    """Tests for detect_data_type() function."""
+
+    def test_detects_sgf(self, tmp_path: Path):
+        """Detects SGF data type."""
+        sgf_file = tmp_path / 'a.sgf'
+        sgf_file.write_text('')
+
+        assert cli_main.detect_data_type(str(tmp_path)) == 'sgf'
+
+    def test_detects_npz(self, tmp_path: Path):
+        """Detects NPZ data type."""
+        npz_path = tmp_path / 'b.npz'
+        np.savez(npz_path, data=['{}'])
+
+        assert cli_main.detect_data_type(str(tmp_path)) == 'npz'
+
+    def test_mixed_formats_raises(self, tmp_path: Path):
+        """Mixed formats raise ValueError."""
+        (tmp_path / 'a.sgf').write_text('')
+        np.savez(tmp_path / 'b.npz', data=['{}'])
+
+        with pytest.raises(ValueError):
+            cli_main.detect_data_type(str(tmp_path))

--- a/tests/unit/test_rest_api.py
+++ b/tests/unit/test_rest_api.py
@@ -1,46 +1,72 @@
-import pathlib
-import sys
+"""Unit tests for REST API (api/rest_api.py).
+
+Tests REST API endpoints for health check and prediction.
+"""
+from __future__ import annotations
+
 import asyncio
 from unittest.mock import patch
 
 import httpx
 import pytest
 
-# Allow importing from project root
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
-
 from api import rest_api
 
 
+# ---------------------------------------------------------------------------
+# Helper Functions
+# ---------------------------------------------------------------------------
+
 def _request(method: str, url: str, **kwargs) -> httpx.Response:
+    """Make a synchronous request to the ASGI app."""
     async def _call() -> httpx.Response:
-        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=rest_api.app), base_url="http://test") as client:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=rest_api.app),
+            base_url="http://test"
+        ) as client:
             return await client.request(method, url, **kwargs)
     return asyncio.run(_call())
 
 
-def test_health_endpoint() -> None:
-    response = _request("GET", "/health")
-    assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+# ---------------------------------------------------------------------------
+# Test Classes
+# ---------------------------------------------------------------------------
 
+class TestHealthEndpoint:
+    """Tests for health check endpoint."""
 
-def test_predict_endpoint_success() -> None:
-    with patch("core.engine.predict", return_value={"move": "pass"}, create=True) as mock_pred:
-        payload = {"input": {"board": []}}
-        response = _request("POST", "/predict", json=payload)
+    def test_returns_ok_status(self):
+        """Health endpoint returns ok status."""
+        response = _request("GET", "/health")
+
         assert response.status_code == 200
-        assert response.json() == {"output": {"move": "pass"}}
-        mock_pred.assert_called_once_with(payload["input"])
+        assert response.json() == {"status": "ok"}
 
 
-def test_predict_invalid_payload() -> None:
-    response = _request("POST", "/predict", json={})
-    assert response.status_code == 422
+class TestPredictEndpoint:
+    """Tests for prediction endpoint."""
 
+    def test_predict_success(self):
+        """Predict endpoint returns prediction on success."""
+        with patch("core.engine.predict", return_value={"move": "pass"}, create=True) as mock_pred:
+            payload = {"input": {"board": []}}
 
-def test_predict_exception_handling() -> None:
-    with patch("core.engine.predict", side_effect=RuntimeError("boom"), create=True):
-        response = _request("POST", "/predict", json={"input": {"x": 1}})
-        assert response.status_code == 500
-        assert response.json()["detail"] == "boom"
+            response = _request("POST", "/predict", json=payload)
+
+            assert response.status_code == 200
+            assert response.json() == {"output": {"move": "pass"}}
+            mock_pred.assert_called_once_with(payload["input"])
+
+    def test_predict_invalid_payload(self):
+        """Predict endpoint returns 422 for invalid payload."""
+        response = _request("POST", "/predict", json={})
+
+        assert response.status_code == 422
+
+    def test_predict_exception_handling(self):
+        """Predict endpoint returns 500 on internal error."""
+        with patch("core.engine.predict", side_effect=RuntimeError("boom"), create=True):
+            response = _request("POST", "/predict", json={"input": {"x": 1}})
+
+            assert response.status_code == 500
+            assert response.json()["detail"] == "boom"

--- a/tests/unit/test_websocket_api.py
+++ b/tests/unit/test_websocket_api.py
@@ -70,7 +70,9 @@ class TestWebSocketPredict:
         server, thread = _start_server()
         try:
             ws = connect(f"ws://127.0.0.1:{PORT}/ws/predict")
-            ws.send(json.dumps({"input": {"board": [[0]], "color": "black"}}))
+            # Use 9x9 board (minimum valid Go board size)
+            board_9x9 = [[0] * 9 for _ in range(9)]
+            ws.send(json.dumps({"input": {"board": board_9x9, "color": "black"}}))
             data = json.loads(ws.recv())
 
             assert data["output"] is not None

--- a/tests/unit/test_websocket_api.py
+++ b/tests/unit/test_websocket_api.py
@@ -1,24 +1,34 @@
+"""Unit tests for WebSocket API (api/websocket_api.py).
+
+Tests WebSocket connection, message handling, and prediction endpoint.
+"""
+from __future__ import annotations
+
 import json
-import pathlib
-import sys
 import threading
 import time
 from unittest.mock import patch
 
 import pytest
-from websockets.sync.client import connect
 import uvicorn
-
-# Add project root to path
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+from websockets.sync.client import connect
 
 from api.websocket_api import app
 
 
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
 PORT = 8765
 
 
-def start_server():
+# ---------------------------------------------------------------------------
+# Helper Functions
+# ---------------------------------------------------------------------------
+
+def _start_server():
+    """Start the WebSocket server in a background thread."""
     config = uvicorn.Config(app, host="127.0.0.1", port=PORT, log_level="info")
     server = uvicorn.Server(config)
     thread = threading.Thread(target=server.run, daemon=True)
@@ -28,83 +38,107 @@ def start_server():
     return server, thread
 
 
-def stop_server(server, thread):
+def _stop_server(server, thread):
+    """Stop the WebSocket server."""
     server.should_exit = True
     thread.join()
 
 
-def test_predict_success():
-    with patch("core.engine.predict", return_value={"move": "D4"}, create=True):
-        server, thread = start_server()
+# ---------------------------------------------------------------------------
+# Test Classes
+# ---------------------------------------------------------------------------
+
+class TestWebSocketPredict:
+    """Tests for WebSocket prediction endpoint."""
+
+    def test_predict_success(self):
+        """Predict returns output on success."""
+        with patch("core.engine.predict", return_value={"move": "D4"}, create=True):
+            server, thread = _start_server()
+            try:
+                ws = connect(f"ws://127.0.0.1:{PORT}/ws/predict")
+                ws.send(json.dumps({"input": {"board": []}}))
+                data = json.loads(ws.recv())
+
+                assert data == {"output": {"move": "D4"}}
+                ws.close()
+            finally:
+                _stop_server(server, thread)
+
+    def test_predict_default_engine(self):
+        """Predict with default engine returns output."""
+        server, thread = _start_server()
         try:
             ws = connect(f"ws://127.0.0.1:{PORT}/ws/predict")
-            ws.send(json.dumps({"input": {"board": []}}))
+            ws.send(json.dumps({"input": {"board": [[0]], "color": "black"}}))
             data = json.loads(ws.recv())
-            assert data == {"output": {"move": "D4"}}
+
+            assert data["output"] is not None
             ws.close()
         finally:
-            stop_server(server, thread)
+            _stop_server(server, thread)
 
 
-def test_invalid_json():
-    server, thread = start_server()
-    try:
-        ws = connect(f"ws://127.0.0.1:{PORT}/ws/predict")
-        ws.send("not json")
-        data = json.loads(ws.recv())
-        assert data["error"] == "invalid_json"
-        ws.close()
-    finally:
-        stop_server(server, thread)
+class TestWebSocketErrorHandling:
+    """Tests for WebSocket error handling."""
+
+    def test_invalid_json(self):
+        """Invalid JSON returns error."""
+        server, thread = _start_server()
+        try:
+            ws = connect(f"ws://127.0.0.1:{PORT}/ws/predict")
+            ws.send("not json")
+            data = json.loads(ws.recv())
+
+            assert data["error"] == "invalid_json"
+            ws.close()
+        finally:
+            _stop_server(server, thread)
+
+    def test_missing_input_key(self):
+        """Missing input key returns error."""
+        server, thread = _start_server()
+        try:
+            ws = connect(f"ws://127.0.0.1:{PORT}/ws/predict")
+            ws.send(json.dumps({"foo": 1}))
+            data = json.loads(ws.recv())
+
+            assert data["error"] == "missing_input"
+            ws.close()
+        finally:
+            _stop_server(server, thread)
 
 
-def test_missing_input_key():
-    server, thread = start_server()
-    try:
-        ws = connect(f"ws://127.0.0.1:{PORT}/ws/predict")
-        ws.send(json.dumps({"foo": 1}))
-        data = json.loads(ws.recv())
-        assert data["error"] == "missing_input"
-        ws.close()
-    finally:
-        stop_server(server, thread)
+class TestWebSocketConnection:
+    """Tests for WebSocket connection handling."""
 
+    def test_ping_pong(self):
+        """Server responds pong to ping."""
+        server, thread = _start_server()
+        try:
+            ws = connect(f"ws://127.0.0.1:{PORT}/ws/predict")
+            ws.send("ping")
 
-def test_ping_pong():
-    server, thread = start_server()
-    try:
-        ws = connect(f"ws://127.0.0.1:{PORT}/ws/predict")
-        ws.send("ping")
-        assert ws.recv() == "pong"
-        ws.close()
-    finally:
-        stop_server(server, thread)
+            assert ws.recv() == "pong"
+            ws.close()
+        finally:
+            _stop_server(server, thread)
 
+    def test_disconnect_and_reconnect(self):
+        """Client can reconnect after disconnect."""
+        server, thread = _start_server()
+        try:
+            ws = connect(f"ws://127.0.0.1:{PORT}/ws/predict")
+            ws.send("ping")
+            ws.recv()
+            ws.close()
 
-def test_disconnect_and_reconnect():
-    server, thread = start_server()
-    try:
-        ws = connect(f"ws://127.0.0.1:{PORT}/ws/predict")
-        ws.send("ping")
-        ws.recv()
-        ws.close()
-        with patch("core.engine.predict", return_value=42, create=True):
-            ws2 = connect(f"ws://127.0.0.1:{PORT}/ws/predict")
-            ws2.send(json.dumps({"input": {"x": 1}}))
-            data = json.loads(ws2.recv())
-            assert data == {"output": 42}
-            ws2.close()
-    finally:
-        stop_server(server, thread)
+            with patch("core.engine.predict", return_value=42, create=True):
+                ws2 = connect(f"ws://127.0.0.1:{PORT}/ws/predict")
+                ws2.send(json.dumps({"input": {"x": 1}}))
+                data = json.loads(ws2.recv())
 
-
-def test_predict_default_engine():
-    server, thread = start_server()
-    try:
-        ws = connect(f"ws://127.0.0.1:{PORT}/ws/predict")
-        ws.send(json.dumps({"input": {"board": [[0]], "color": "black"}}))
-        data = json.loads(ws.recv())
-        assert data["output"] is not None
-        ws.close()
-    finally:
-        stop_server(server, thread)
+                assert data == {"output": 42}
+                ws2.close()
+        finally:
+            _stop_server(server, thread)


### PR DESCRIPTION
- Fix parameter naming: board_size -> size, komi_value -> komi
- Add docstrings to all test modules and classes
- Remove manual sys.path.insert calls (conftest.py handles this)
- Add parametrize ids for all @pytest.mark.parametrize
- Add type annotations to fixtures and test parameters
- Organize tests into classes following naming convention
- Fix import order to follow PEP8 and project guidelines